### PR TITLE
Add [POST] /coupon/v1/coupons

### DIFF
--- a/coupon/README.md
+++ b/coupon/README.md
@@ -7,6 +7,7 @@ This documentation describes the Jetpack Partner Coupon API and how to get start
 - [Specification](#specification)
 - [Authentication](#authentication)
 - [Step-by-step integration guide](#step-by-step-integration-guide)
+- [Bulk operations](#bulk-operations)
 
 ## Specification
 
@@ -75,3 +76,33 @@ The response will be a JSON object of the coupon that looks something like this:
 ```
 
 After revoking a coupon, its `expired` value will be updated to `true`.
+
+## Bulk operations
+
+Some of the individual coupon operations also exists as bulk operations to reduce the amount of HTTP request required to manage coupons.
+
+### 1. Issue coupons
+
+To issue coupons in bulk you have to make a `POST` request to the `/wpcom/v2/jetpack-partner/coupon/v1/coupons` endpoint - you can find our [bash example here](./examples/issue-coupons.sh).
+
+The response will be a JSON array of the newly issued coupon that looks something like this:
+```json
+[
+  {
+    "coupon_code":"partner_0.TG9yZW0gaXBzd",
+    "products":["jetpack-backup-daily"],
+    "discount":100,
+    "used_at":null,
+    "expired":false
+  },
+  {
+    "coupon_code":"partner_0.Ac2kF3gV8oP2x",
+    "products":["jetpack-backup-daily"],
+    "discount":100,
+    "used_at":null,
+    "expired":false
+  }
+]
+```
+
+Once you've issued the coupons, they can be immediately used for a Jetpack.com purchase by any customer that has the coupon code.

--- a/coupon/examples/issue-coupons.sh
+++ b/coupon/examples/issue-coupons.sh
@@ -6,6 +6,6 @@ COUPONS_JSON=$(curl "https://public-api.wordpress.com/wpcom/v2/jetpack-partner/c
   --silent \
   --header "Authorization: Bearer $ACCESS_TOKEN" \
   --header "Content-Type: application/json" \
-  --data "{\"preset\":\"$PRESET\",\"quantity\":\"$QUANTITY\"}" \
+  --data "{\"preset\":\"$PRESET\",\"quantity\":$QUANTITY}" \
   -X POST)
 echo $COUPONS_JSON

--- a/coupon/examples/issue-coupons.sh
+++ b/coupon/examples/issue-coupons.sh
@@ -1,0 +1,11 @@
+ACCESS_TOKEN= your access token
+PRESET= unique preset slug
+QUANTITY= the quantity of coupons
+
+COUPONS_JSON=$(curl "https://public-api.wordpress.com/wpcom/v2/jetpack-partner/coupon/v1/coupons" \
+  --silent \
+  --header "Authorization: Bearer $ACCESS_TOKEN" \
+  --header "Content-Type: application/json" \
+  --data "{\"preset\":\"$PRESET\",\"quantity\":\"$QUANTITY\"}" \
+  -X POST)
+echo $COUPONS_JSON

--- a/coupon/spec.yml
+++ b/coupon/spec.yml
@@ -3,7 +3,7 @@ openapi: 3.0.0
 info:
   title: 'Jetpack Partner - Coupon API'
   description: 'A set of endpoints that allows Jetpack partners to issue and manage coupons.'
-  version: 0.2.0
+  version: 0.3.0
   contact:
     email: partners@jetpack.com
   license:
@@ -12,7 +12,9 @@ info:
 
 tags:
   - name: coupon
-    description: 'A set of endpoints that allows Jetpack partners to issue and manage coupons.'
+    description: 'A set of endpoints that allows Jetpack partners to issue and manage individual coupon.'
+  - name: coupons
+    description: 'A set of endpoints that allows Jetpack partners to issue and manage a collection of coupons.'
   - name: presets
     description: 'A set of endpoints that allows Jetpack partners to interact with coupon presets.'
 
@@ -123,6 +125,52 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /coupons:
+    post:
+      tags:
+        - coupons
+      summary: 'Issue a collection of new coupons.'
+      operationId: issueCoupons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                preset:
+                  description: A coupon preset slug. See the Preset schema for more information.
+                  type: string
+                  example: 'preset1'
+                quantity:
+                  description: The amount of coupons that should be returned.
+                  type: integer
+                  format: int32
+                  minimum: 1
+                  maximum: 500
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: 'OK. Response body contains a list of newly issued coupons.'
+          headers:
+            X-Jetpack-Request-Id:
+              $ref: '#/components/headers/X-Jetpack-Request-Id'
+          content:
+            application/json:
+              schema:
+                type: array
+                description: 'A list of coupon objects.'
+                items:
+                  $ref: '#/components/schemas/Coupon'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/NoPartner'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalError'
 

--- a/coupon/spec.yml
+++ b/coupon/spec.yml
@@ -12,9 +12,9 @@ info:
 
 tags:
   - name: coupon
-    description: 'A set of endpoints that allows Jetpack partners to issue and manage individual coupon.'
+    description: 'A set of endpoints that allows Jetpack partners to issue and manage coupons.'
   - name: coupons
-    description: 'A set of endpoints that allows Jetpack partners to issue and manage a collection of coupons.'
+    description: 'A set of endpoints that allows Jetpack partners to issue and manage coupons in bulk.'
   - name: presets
     description: 'A set of endpoints that allows Jetpack partners to interact with coupon presets.'
 
@@ -132,7 +132,7 @@ paths:
     post:
       tags:
         - coupons
-      summary: 'Issue a collection of new coupons.'
+      summary: 'Issue new coupons.'
       operationId: issueCoupons
       requestBody:
         content:


### PR DESCRIPTION
This PR will update the coupon spec and readme with a new `[POST] /coupon/v1/coupons` endpoint to issue coupons in bulk.

The new bulk endpoint is a copy of the `[POST] /coupon/v1/coupon` endpoint but instead accepts a new `quantity` parameter and returns and array of coupon objects.